### PR TITLE
ci: Use UPX compression

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,10 @@ jobs:
         run: chmod u+rx millw && ./millw -i cli.nativeLink && ./millw -i cli.assembly
       - name: Copy artifact
         run: cp "out/cli/nativeLink.dest/out" "cylang" && cp "out/cli/assembly.dest/out.jar" "cylang.jar"
+      - name: Install UPX
+        run: sudo apt install -y upx-ucl
+      - name: Compress CYLang executable using UPX
+        run: upx --best cylang
       - name: Upload native artifact
         uses: actions/upload-artifact@v3
         with:
@@ -51,6 +55,10 @@ jobs:
         run: ./millw.bat -i cli.nativeLink
       - name: Copy artifact
         run: cp "./out/cli/nativeLink.dest/out" "cylang.exe"
+      - name: Install UPX
+        run: choco install upx
+      - name: Compress CYLang executable using UPX
+        run: upx --best cylang.exe
       - name: Upload native artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,15 +25,13 @@ jobs:
         run: chmod u+rx millw && ./millw -i main.testAll
 
   cli-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Build CLI
         run: chmod u+rx millw && ./millw -i cli.nativeLink && ./millw -i cli.assembly
       - name: Copy artifact
         run: cp "out/cli/nativeLink.dest/out" "cylang" && cp "out/cli/assembly.dest/out.jar" "cylang.jar"
-      - name: Install UPX
-        run: sudo apt install -y upx-ucl
       - name: Compress CYLang executable using UPX
         run: upx --best cylang
       - name: Upload native artifact


### PR DESCRIPTION
The results of the compression can be seen here : https://github.com/JordanViknar/cylang-jv-branches/actions

I know this pull request isn't that useful, considering the CYLang executables are already pretty small, but eh... it's worth it just to crush CYLang to 1/5 of its original size.

Some testing has been done, and the compressed versions of CYLang (both Windows & Linux) seem to work properly.

*The reason Ubuntu 22.04 is used : it comes with UPX 3.96, which comes with a few fixes compared to 3.95.*